### PR TITLE
read from uri fragment in addition to query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ipns | ipns kunalm.xyz | Opens the domain on IPNS.
 
 2. Click `Manage Search Engines`.
 
-3. Add a new search engine with the URL `http://wagmify.me/?q=%s`. Set both name and keyword to `wagmify`.
+3. Add a new search engine with the URL `https://wagmify.me/#?q=%s`. Set both name and keyword to `wagmify`.
 
 4. Make this the default search engine.
 

--- a/index.html
+++ b/index.html
@@ -55,6 +55,23 @@
         window.location = url
       }
 
+      function getQueryParams() {
+        // First, check if the command is in the query params
+        const searchParams = new URLSearchParams(window.location.search)
+        const searchQuery = searchParams.get("q")
+        if (searchQuery) {
+          return searchQuery.split(" ")
+        }
+        // Next, check if it's in the hash params
+        const hashParams = new URLSearchParams((window.location.hash ?? '').split('?')[1])
+        const hashQuery = hashParams.get("q")
+        if (hashQuery) {
+          return hashQuery.split(" ")
+        }
+        // Otherwise, there is no command set
+        return ["homepage"]
+      }
+
       // Top 100 CoinGecko coins. Hardcoded to provide fast lookups.
       const coingeckoSymbolToID = {
         'btc': 'bitcoin',
@@ -197,14 +214,11 @@
         'ohm': '0x383518188c0c6d7730d91b2c03a03c837814a899',
       }
 
-      const params = new URLSearchParams(window.location.search)
-      const queryParam = params.get("q")
-      const query = queryParam.split(" ")
-      if (!query) {
-        window.location = "https://www.google.com"
-      }
+      const query = getQueryParams()
+
       const commandName = query[0]
       switch (commandName) {
+        case "homepage":
         case "commands":
         case "help":
           break;
@@ -373,7 +387,7 @@
           if (query.length === 1 && query[0].endsWith('.eth')) {
             redirectTo(`https://etherscan.io/address/${commandName}`)
           } else {
-            redirectTo(`http://www.google.com/search?q=${encodeURIComponent(queryParam)}`)
+            redirectTo(`http://www.google.com/search?q=${encodeURIComponent(query.join(" "))}`)
           }
         }
       }


### PR DESCRIPTION
Read from the URL [hash parameters](https://en.wikipedia.org/wiki/URI_fragment), which aren't sent to the remote server.


Test Plan:

```
kunal@machine:~/Desktop/Projects/crypto/wagmify.me (urifragment)$ python3 -m http.server
```

Try a series of URLs:
`localhost:8000` -> Homepage
`localhost:8000?q=price klima` -> Coingecko
`localhost:8000#?q=price klima` -> Coingecko
`localhost:8000?q=blah blah` -> Google
`localhost:8000#?q=blah blah` -> Google